### PR TITLE
PR: Fix absolute paths in OfficeLocator android project

### DIFF
--- a/src/CampusRouting/OfficeLocator.Android/OfficeLocator.Android.csproj
+++ b/src/CampusRouting/OfficeLocator.Android/OfficeLocator.Android.csproj
@@ -96,10 +96,10 @@
   <Import Project="..\OfficeLocator.Shared\OfficeLocator.Shared.projitems" Label="Shared" />
   <!-- Trick to make Content files compile as AndroidAsset -->
   <ItemGroup>
-    <AndroidAsset Include="C:\devtopia\mort5161\EsriCampusApp\src\OfficeLocator.Shared\MarkerA.png">
+    <AndroidAsset Include="..\OfficeLocator.Shared\MarkerA.png">
       <Link>Assets\MarkerA.png</Link>
     </AndroidAsset>
-    <AndroidAsset Include="C:\devtopia\mort5161\EsriCampusApp\src\OfficeLocator.Shared\MarkerB.png">
+    <AndroidAsset Include="..\OfficeLocator.Shared\MarkerB.png">
       <Link>Assets\MarkerB.png</Link>
     </AndroidAsset>
   </ItemGroup>


### PR DESCRIPTION
A couple resources in the CampusRouting OfficeLocator.Android project are [included by absolute path](https://github.com/Esri/arcgis-runtime-demos-dotnet/blob/master/src/CampusRouting/OfficeLocator.Android/OfficeLocator.Android.csproj#L97-L105), which prevents the project from building on my machine: 
```
2>C:\runtime\DotNet\arcgis-runtime-demos-dotnet\src\CampusRouting\OfficeLocator.Shared\MarkerA.png : warning XA0101: @(Content) build action is not supported
2>C:\runtime\DotNet\arcgis-runtime-demos-dotnet\src\CampusRouting\OfficeLocator.Shared\MarkerB.png : warning XA0101: @(Content) build action is not supported
2>C:\Program Files (x86)\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(939,2): error MSB3030: Could not copy the file "C:\devtopia\mort5161\EsriCampusApp\src\OfficeLocator.Shared\MarkerA.png" because it was not found.
2>C:\Program Files (x86)\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(939,2): error MSB3030: Could not copy the file "C:\devtopia\mort5161\EsriCampusApp\src\OfficeLocator.Shared\MarkerB.png" because it was not found.
2>
2>Build FAILED.
```

This PR changes it to relative path, allowing me to build the app.