### PR TITLE
SymbolEditorSampleUpdate_U10

### DIFF
--- a/src/SymbolEditor/SymbolEditorApp/Controls/SymbolEditor.xaml.cs
+++ b/src/SymbolEditor/SymbolEditorApp/Controls/SymbolEditor.xaml.cs
@@ -64,7 +64,7 @@ namespace SymbolEditorApp.Controls
 
             if (MetroDialog.ShowDialog("Symbol Picker", picker, this) == true)
             {
-                var symbol = picker.SelectedItem?.Symbol;
+                var symbol = picker.SelectedItem?.StyleSymbol;
                 if (symbol != null)
                     Symbol = symbol;
             }

--- a/src/SymbolEditor/SymbolEditorApp/Controls/SymbolPicker.xaml
+++ b/src/SymbolEditor/SymbolEditorApp/Controls/SymbolPicker.xaml
@@ -38,10 +38,10 @@
             </ListView.ItemsPanel>
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <Grid ToolTip="{Binding Name}" Height="60" >
-                        <esri:SymbolDisplay Symbol="{Binding Symbol}" HorizontalAlignment="Center" VerticalAlignment="Center" 
+                    <Grid ToolTip="{Binding SymbolStyleSearchResult.Name}" Height="60" >
+                        <esri:SymbolDisplay Symbol="{Binding StyleSymbol}" HorizontalAlignment="Center" VerticalAlignment="Center" 
                                             Margin="0,0,0,14" />
-                        <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis"
+                        <TextBlock Text="{Binding SymbolStyleSearchResult.Name}" TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Bottom" HorizontalAlignment="Center" />
                     </Grid>
                 </DataTemplate>

--- a/src/SymbolEditor/SymbolEditorApp/SymbolEditorApp.csproj
+++ b/src/SymbolEditor/SymbolEditorApp/SymbolEditorApp.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="100.7.0" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="100.7.1" />
-    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Preview" Version="100.7.1" />
+    <PackageReference Include="Esri.ArcGISRuntime.WPF" Version="100.10.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="100.10.0" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Preview" Version="100.10.0" />
     <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0660" />
     <PackageReference Include="UniversalWPF" Version="0.9.0" />
   </ItemGroup>


### PR DESCRIPTION
WebStyle are style files that are hosted online and available as portal item. SymbolEditor sample has been updated to show case use of webstyle. This feature is delivered in update 10 release.

Besides local stylx file selection, Symbol Style selection drop-down now offers to choose :
- An esri registered webstyle.  These are available out-of-the box in AGOL and ArcGIS Enterprise.
- A custom webstyle published on a portal.

Sample also uses GetSymbolAsyn() for fetching search result.